### PR TITLE
Update Pagerduty template to version 2.0.1

### DIFF
--- a/incident-management/pagerduty.yaml
+++ b/incident-management/pagerduty.yaml
@@ -3,6 +3,27 @@
 #   The Sensu PagerDuty Handler is a Sensu Event Handler that alerts to
 #   the PagerDuty incident reponse service.
 #
+# Prerequisites 
+# 
+#   1. Pagerduty Integration Key
+# 
+#      To obtain a Pagerduty Integration Key, please visit your Pagerduty 
+#      dashboard, browse to "Services" > "Event Rules", and copy your 
+#      "Pagerduty Integration Key". 
+# 
+#   2. Secrets Management 
+# 
+#      This template uses the Sensu Go "env" Secrets Provider. To use this 
+#      secret with this template, add the $PAGERDUTY_INTEGRATION_KEY 
+#      environment variable to your Sensu Backend host nodes or containers. 
+#      Most cloud-based Secrets Management tools (e.g. Kubernetes Secrets) have 
+#      built-in solutions for managing environment variables, so you may need 
+#      to consult your secrets manager documentation. Alternatively, you may 
+#      modify the provided Secret resource (e.g. use the Vault Provider). If 
+#      you can't modify environment variables or use a first-class Secrets 
+#      Management solution, you may directly configure the Handler command to 
+#      use the --token flag, but this is not recommended. 
+#      
 # Instructions
 #   1. Add "pagerduty" to the "incident-management" handler set.
 #
@@ -49,72 +70,76 @@ spec:
   - not_silenced
   handlers: null
   runtime_assets:
-  - sensu/sensu-pagerduty-handler:1.3.2
+  - sensu/sensu-pagerduty-handler:2.0.1
   secrets:
   - name: PAGERDUTY_TOKEN
-    secret: pagerduty_token
+    secret: pagerduty_integration_key
   timeout: 0
   type: pipe
 ---
 type: Secret
 api_version: secrets/v1
 metadata:
-  name: pagerduty_token
+  name: pagerduty_integration_key
 spec:
   provider: env
-  id: PAGERDUTY_TOKEN
+  id: PAGERDUTY_INTEGRATION_KEY
 ---
 type: Asset
 api_version: core/v2
 metadata:
-  name: sensu-pagerduty-handler:1.3.2
   annotations:
-    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
     io.sensu.bonsai.api_url: https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler
-    io.sensu.bonsai.tier: Supported
-    io.sensu.bonsai.version: 1.3.2
-    io.sensu.bonsai.namespace: sensu
     io.sensu.bonsai.name: sensu-pagerduty-handler
+    io.sensu.bonsai.namespace: sensu
     io.sensu.bonsai.tags: handler
+    io.sensu.bonsai.tier: Supported
+    io.sensu.bonsai.url: https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler
+    io.sensu.bonsai.version: 2.0.1
+  name: sensu/sensu-pagerduty-handler:2.0.1
 spec:
   builds:
-    - url: https://assets.bonsai.sensu.io/e6722787284bd20f68d0375ee927aa0ec5d2e57b/sensu-pagerduty-handler_1.3.2_windows_386.tar.gz
-      sha512: 10eb353c624fa1853a5b6175366e6ae325315208b2289b1191629004737dbacbfc576f54b95a89560a5226e24aa0438458256b04ac1ffdc9876cf0afdf6441dd
-      filters:
-        - entity.system.os == 'windows'
-        - entity.system.arch == '386'
-    - url: https://assets.bonsai.sensu.io/e6722787284bd20f68d0375ee927aa0ec5d2e57b/sensu-pagerduty-handler_1.3.2_windows_amd64.tar.gz
-      sha512: 83b51af2254470edbeabf840ae556f113452133f4abbe41e0ce5e0ac37d00262a17646d38ddc23fa16f39706f3506ade902eb1b29429bb0898cfd8c5ce0b0e36
-      filters:
-        - entity.system.os == 'windows'
-        - entity.system.arch == 'amd64'
-    - url: https://assets.bonsai.sensu.io/e6722787284bd20f68d0375ee927aa0ec5d2e57b/sensu-pagerduty-handler_1.3.2_darwin_386.tar.gz
-      sha512: 46826d62f586f935d6a8686da7315105a8161364cbf7665943b3fd349cbe194ab1b5c1f312616014472f2499858f8c595ac5bc56b191df4761632bfa42b1b97c
-      filters:
-        - entity.system.os == 'darwin'
-        - entity.system.arch == '386'
-    - url: https://assets.bonsai.sensu.io/e6722787284bd20f68d0375ee927aa0ec5d2e57b/sensu-pagerduty-handler_1.3.2_darwin_amd64.tar.gz
-      sha512: 8f14359b5e9f881a495b7b2019b3ecd080421c43c07a96856ee607ab710f57397fd65fdb288cc672eac201e280fa7d87fb2a23f72089665dc0dfc25b27bc64fc
-      filters:
-        - entity.system.os == 'darwin'
-        - entity.system.arch == 'amd64'
-    - url: https://assets.bonsai.sensu.io/e6722787284bd20f68d0375ee927aa0ec5d2e57b/sensu-pagerduty-handler_1.3.2_linux_armv7.tar.gz
-      sha512: 77d2a57ce4e806766faf766a592d5623ee31b634d5a118eaf1423a6aec14819cf569bdeb7f557c727f4c3f67a8127b771ff41a3d2e1ce17ffe9935a2bdb00a8a
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'armv7'
-    - url: https://assets.bonsai.sensu.io/e6722787284bd20f68d0375ee927aa0ec5d2e57b/sensu-pagerduty-handler_1.3.2_linux_arm64.tar.gz
-      sha512: be5a306fcfbec1f3be9ef8f5300dfcbc59425681f4108bf844dc6e7586567e5f5b207f448f335cff0f2bc3816c845bacffa21ed5a124dfb902b7894b4df0acb9
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'arm64'
-    - url: https://assets.bonsai.sensu.io/e6722787284bd20f68d0375ee927aa0ec5d2e57b/sensu-pagerduty-handler_1.3.2_linux_386.tar.gz
-      sha512: 4fea313808cd4e899248f07928386fc84d52cae7013b41d26d6bb9bfac8a0fb4f84cce4ffbeb38d4f8bbb8e4e4e55f72942bfb244d8f2c9f862bcdfb5775da6c
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == '386'
-    - url: https://assets.bonsai.sensu.io/e6722787284bd20f68d0375ee927aa0ec5d2e57b/sensu-pagerduty-handler_1.3.2_linux_amd64.tar.gz
-      sha512: f0236559b696270ea74ac51274269b8af28ed90901b43e2d13ebed1de34f4faf7a29f06268268a0a41a08721ce67fa0c1f245ad54e444eb06f26fbd87163b687
-      filters:
-        - entity.system.os == 'linux'
-        - entity.system.arch == 'amd64'
+  - filters:
+    - entity.system.os == 'windows'
+    - entity.system.arch == '386'
+    headers: null
+    sha512: 1ef39d1084adbdb8aab917c8d052ae944b586630b909eebf6d34e3f2490cb9f218191c6b129edf6ecedc74b26261f67f69aff2cbb4f5e2e6af0ed22d18c1b99c
+    url: https://assets.bonsai.sensu.io/e930fc9c21b835896216ca4594c7990111b54630/sensu-pagerduty-handler_2.0.1_windows_386.tar.gz
+  - filters:
+    - entity.system.os == 'windows'
+    - entity.system.arch == 'amd64'
+    headers: null
+    sha512: c13db708bf391bf5aeb5dd6681cb8c363e6794932aef3cb4752c4fd23482df42966daea2df7d5085d8efc27e868c59122fa84b58390cf9a00454bdff4d5dd000
+    url: https://assets.bonsai.sensu.io/e930fc9c21b835896216ca4594c7990111b54630/sensu-pagerduty-handler_2.0.1_windows_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'darwin'
+    - entity.system.arch == 'amd64'
+    headers: null
+    sha512: ae7c2771ab94cf5d8ff47a08be827d486fa2b9599f41e83227b28281688c19e2466785ea2e0523e29d1bacfa13988bc214c16cb01a54b3524293cb67cb6b118b
+    url: https://assets.bonsai.sensu.io/e930fc9c21b835896216ca4594c7990111b54630/sensu-pagerduty-handler_2.0.1_darwin_amd64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'armv7'
+    headers: null
+    sha512: b80b31eb33e4d53826b55e8d29cf463712e2ae0a28793a7948bc25c4bdd83ec872b5e461bd2063b32cccf512734e18ae9333965ec29c8e2e27d7eb76582f7ffa
+    url: https://assets.bonsai.sensu.io/e930fc9c21b835896216ca4594c7990111b54630/sensu-pagerduty-handler_2.0.1_linux_armv7.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'arm64'
+    headers: null
+    sha512: 398e74b3e35472263c22415f677a50a4c095fea61de8ade04e7c19e50b09064a383ea3bdac7539774f5fc4b02588d3bc5c5feb52aa8c346038bd0bade1ccc3d6
+    url: https://assets.bonsai.sensu.io/e930fc9c21b835896216ca4594c7990111b54630/sensu-pagerduty-handler_2.0.1_linux_arm64.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == '386'
+    headers: null
+    sha512: 4ed80ce77fc22e26f4a5526457fa491bbe1feaea5964ce5ce55672d970d414cd6cca197a6de79e8c558d38fe4455c5352b82ce1a7a854d7907129baebd8274a7
+    url: https://assets.bonsai.sensu.io/e930fc9c21b835896216ca4594c7990111b54630/sensu-pagerduty-handler_2.0.1_linux_386.tar.gz
+  - filters:
+    - entity.system.os == 'linux'
+    - entity.system.arch == 'amd64'
+    headers: null
+    sha512: 6d499ae6edeb910eb807abfb141be3b9a72951911f804d5a7cc98fbbea15dc4cc6c456f1663124c1db51111c8fd42dab39d1d093356e555785f21ef5f95ffb06
+    url: https://assets.bonsai.sensu.io/e930fc9c21b835896216ca4594c7990111b54630/sensu-pagerduty-handler_2.0.1_linux_amd64.tar.gz
+  filters: null
+  headers: null


### PR DESCRIPTION
- Pagerduty integration version 2.0.1 
- Rename Pagerduty Secret to `pagerduty_integration_key` to reflect Pagerduty terminology (there is no "Pagerduty Token") 